### PR TITLE
show age for passwords in detail view

### DIFF
--- a/app/src/main/res/layout/decrypt_layout.xml
+++ b/app/src/main/res/layout/decrypt_layout.xml
@@ -43,6 +43,19 @@
                 android:textSize="24sp"
                 android:textStyle="bold"
                 tools:ignore="HardcodedText" />
+
+            <TextView
+                android:id="@+id/crypto_password_last_changed"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center_vertical"
+                android:layout_marginLeft="16dp"
+                android:layout_marginStart="16dp"
+                android:text="LAST CHANGED HERE"
+                android:textColor="@color/grey_500"
+                android:textIsSelectable="false"
+                android:textSize="18sp"
+                tools:ignore="HardcodedText" />
         </LinearLayout>
 
         <ImageView

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -194,4 +194,5 @@
     <string name="autofill_ins_1_hint">Bildschirmfoto Accessibility Services</string>
     <string name="autofill_ins_2_hint">Bildschirmfoto des Schalters in Accessibility Services</string>
     <string name="autofill_ins_3_hint">Bildschirmfoto von Autofill in Aktion</string>
+    <string name="last_changed">Zuletzt geändert %s</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -96,6 +96,7 @@
     <string name="copy_password">Copy password</string>
     <string name="copy_username">Copy username</string>
     <string name="share_as_plaintext">Share as plaintext</string>
+    <string name="last_changed">Last changed %s</string>
 
     <!-- Preferences -->
     <string name="pref_git_title">Git</string>


### PR DESCRIPTION
Implements #330.
This fetches the latest commit where the respective password file was
changed from the current HEAD and outputs the relative time since
the last change on the decrypt page.

NOTE: translations are incomplete because I only speak so many languages :)
If someone hits me up with other translations I'll be happy to include them
in this PR.